### PR TITLE
Fix post block condition for flowdockNotify

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ pipeline {
         }
     }
     post { 
-        change { 
+        changed { 
             flowdockNotify this,'XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX', '#test'
         }
     }

--- a/vars/flowdockNotify.txt
+++ b/vars/flowdockNotify.txt
@@ -18,7 +18,7 @@ library 'flowdock-notifier'
 pipeline {
     // ...
     post { 
-        change { 
+        changed { 
             flowdockNotify this,'XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX', '#test'
         }
     }


### PR DESCRIPTION
"change" is not a valid condition. Valid conditionss are [always, changed, fixed, regression, aborted, failure, success, unstable, notBuilt, cleanup]. Tested on Jenkins ver. 2.117.